### PR TITLE
スペックをDRYに保つ

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -12,14 +12,10 @@ RSpec.describe ProjectsController, type: :controller do
       it 'responds successfully' do
         sign_in @user
         get :index
-        expect(response).to be_successful
-      end
-
-      # 200レスポンスを返すこと
-      it 'returns a 200 response' do
-        sign_in @user
-        get :index
-        expect(response).to have_http_status '200'
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status '200'
+        end
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TasksController, type: :controller do
     it 'responds with JSON formatted output' do
       sign_in user
       get :show, format: :json, params: { project_id: project.id, id: task.id }
-      expect(response.content_type).to include('application/json')
+      expect(response).to have_content_type :json
     end
   end
 
@@ -16,7 +16,7 @@ RSpec.describe TasksController, type: :controller do
       new_task = { name: 'New test task' }
       sign_in user
       post :create, format: :json, params: { project_id: project.id, task: new_task }
-      expect(response.content_type).to include('application/json')
+      expect(response).to have_content_type :json
     end
 
     it 'adds a new task to the project' do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,16 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe TasksController, type: :controller do
-  before do
-    @user = FactoryBot.create(:user)
-    @project = FactoryBot.create(:project, owner: @user)
-    @task = @project.tasks.create!(name: 'Test task')
-  end
+  include_context 'project setup'
 
   describe '#show' do
     it 'responds with JSON formatted output' do
-      sign_in @user
-      get :show, format: :json, params: { project_id: @project.id, id: @task.id }
+      sign_in user
+      get :show, format: :json, params: { project_id: project.id, id: task.id }
       expect(response.content_type).to include('application/json')
     end
   end
@@ -18,24 +14,24 @@ RSpec.describe TasksController, type: :controller do
   describe '#create' do
     it 'responds with JSON formatted output' do
       new_task = { name: 'New test task' }
-      sign_in @user
-      post :create, format: :json, params: { project_id: @project.id, task: new_task }
+      sign_in user
+      post :create, format: :json, params: { project_id: project.id, task: new_task }
       expect(response.content_type).to include('application/json')
     end
 
     it 'adds a new task to the project' do
       new_task = { name: 'New test task' }
-      sign_in @user
+      sign_in user
       expect {
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.to change(@project.tasks, :count).by(1)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.to change(project.tasks, :count).by(1)
     end
 
     it 'requires authentication' do
       new_task = { name: 'New test task' }
       expect {
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.not_to change(@project.tasks, :count)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.not_to change(project.tasks, :count)
       expect(response).not_to be_successful
     end
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task do
+    
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,32 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Note, type: :model do
-  # ファクトリで関連するデータを生成する
-  it 'generates associated data from a factory' do
-    note = FactoryBot.create(:note)
-    puts "This note's project is #{note.project.inspect}"
-    puts "This note's user is #{note.user.inspect}"
-  end
-
-  before do
-    @user = User.create(
-      first_name: 'Joe',
-      last_name: 'Tester',
-      email: 'tester@example.com',
-      password: 'dottle-nouveau-pavilion-tight-furze'
-    )
-
-    @project = @user.projects.create(
-      name: 'Test Project'
-    )
-  end
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
 
   # ユーザー、プロジェクト、メッセージがあれば有効な状態であること
   it 'is valid with a user, project, and message' do
     note = described_class.new(
       message: 'This is a sample note.',
-      user: @user,
-      project: @project
+      user: user,
+      project: project
     )
 
     expect(note).to be_valid
@@ -41,18 +24,22 @@ RSpec.describe Note, type: :model do
 
   # 文字列に一致するメッセージを検索する
   describe 'search message for a term' do
-    before do
-      @note1 = @project.notes.create(
+    let!(:note1) do
+      project.notes.create(
         message: 'This is the first note.',
-        user: @user
+        user: user
       )
-      @note2 = @project.notes.create(
+    end
+    let!(:note2) do
+      project.notes.create(
         message: 'This is the second note.',
-        user: @user
+        user: user
       )
-      @note3 = @project.notes.create(
+    end
+    let!(:note3) do
+      project.notes.create(
         message: 'First, preheat the oven.',
-        user: @user
+        user: user
       )
     end
 
@@ -60,7 +47,7 @@ RSpec.describe Note, type: :model do
     context 'when a match is found' do
       # 検索文字列に一致するメモを返すこと
       it 'returns notes that match the search term' do
-        expect(described_class.search('first')).to include(@note1, @note3)
+        expect(described_class.search('first')).to include(note1, note3)
       end
     end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  let(:project) { FactoryBot.create(:project) }
+
+  it 'is valid with a project and name' do
+    task = Task.new(
+      project: project,
+      name: 'Test task'
+    )
+
+    expect(task).to be_valid
+  end
+
+  it 'is invalid without a project' do
+    task = Task.new(project: nil)
+    task.valid?
+    expect(task.errors[:project]).to include('must exist')
+  end
+
+  it 'is invalid without a name' do
+    task = Task.new(name: nil)
+    task.valid?
+    expect(task.errors[:name]).to include("can't be blank")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,5 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include RequesSpecHelper, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/support/contexts/project_setup.rb
+++ b/spec/support/contexts/project_setup.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.shared_context 'project setup' do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, owner: user) }
+  let(:task) { project.tasks.create!(name: 'Test task') }
+end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,13 @@
+module LoginSupport
+  def sign_in_as(user)
+    visit root_path
+    click_link 'Sign in'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+    click_button 'Log in'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/support/matchers/content_type.rb
+++ b/spec/support/matchers/content_type.rb
@@ -1,0 +1,32 @@
+RSpec::Matchers.define :have_content_type do |expected|
+  match do |actual|
+    begin
+      actual.content_type.include? content_type(expected)
+    rescue ArgumentError
+      false
+    end
+  end
+
+  failure_message do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+      "(#{actual.content_type})\" to be Content Type " +
+      "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  failure_message_when_negated do |actual|
+    "Expected \"#{content_type(actual.content_type)} " +
+      "(#{actual.content_type})\" to not be Content Type " +
+      "\"#{content_type(expected)}\" (#{expected})"
+  end
+
+  def content_type(type)
+    types = {
+      html: 'text/html',
+      json: 'application/json'
+    }
+
+    types[type.to_sym] || 'unknown content type'
+  end
+end
+
+RSpec::Matchers.alias_matcher :be_content_type, :have_content_type

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -3,12 +3,9 @@ require 'rails_helper'
 RSpec.describe "Projects", type: :system do
   scenario 'user creates a new project' do
     user = FactoryBot.create(:user)
+    sign_in user
 
     visit root_path
-    click_link 'Sign in'
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-    click_button 'Log in'
 
     expect {
       click_link 'New Project'

--- a/spec/system/projects_spec.rb
+++ b/spec/system/projects_spec.rb
@@ -13,5 +13,11 @@ RSpec.describe "Projects", type: :system do
       fill_in 'Description', with: 'Trying out Capybara'
       click_button 'Create Project'
     }.to change(user.projects, :count).by(1)
+
+    aggregate_failures do
+      expect(page).to have_content 'Project was successfully created'
+      expect(page).to have_content 'Test Project'
+      expect(page).to have_content "Owner: #{user.name}"
+    end
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,24 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe "Tasks", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project, name: 'RSpec tutorial', owner: user) }
+  let!(:task) { project.tasks.create!(name: 'Finish RSpec tutorial') }
+
   scenario 'user toggles a task', js: true do
-    user = FactoryBot.create(:user)
-    project = FactoryBot.create(:project, name: 'RSpec tutorial', owner: user)
-    task = project.tasks.create!(name: 'Finish RSpec tutorial')
-
     sign_in user
+    go_to_project 'RSpec tutorial'
+    complete_task 'Finish RSpec tutorial'
 
-    visit root_path
+    expect_complete_task "label#task_#{task.id}.completed"
 
-    click_link 'RSpec tutorial'
-    check 'Finish RSpec tutorial'
-
-    expect(page).to have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to be_completed
-
-    uncheck 'Finish RSpec tutorial'
+    undo_complete_task 'Finish RSpec tutorial'
 
     expect(page).not_to have_css "label#task_#{task.id}.completed"
     expect(task.reload).not_to be_completed
+  end
+
+  def go_to_project(name)
+    visit root_path
+    click_link name
+  end
+
+  def complete_task(name)
+    check name
+  end
+
+  def undo_complete_task(name)
+    uncheck name
+  end
+
+  def expect_complete_task(name)
+    aggregate_failures do
+      expect(page).to have_css name
+      expect(task.reload).to be_completed
+    end
+  end
+
+  def expect_incomplete_task(name)
+    aggregate_failures do
+      expect(page).not_to have_css "label#task_#{task.id}.completed"
+      expect(task.reload).not_to be_completed
+    end
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe "Tasks", type: :system do
     project = FactoryBot.create(:project, name: 'RSpec tutorial', owner: user)
     task = project.tasks.create!(name: 'Finish RSpec tutorial')
 
+    sign_in user
+
     visit root_path
-    click_link 'Sign in'
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-    click_button 'Log in'
 
     click_link 'RSpec tutorial'
     check 'Finish RSpec tutorial'


### PR DESCRIPTION
- サポートモジュール
- letで遅延読み込みする
- shared_context (contextの共有)
- カスタムマッチャー
- aggregate_failures （失敗の集約）
- テストの可読性を改善する
